### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+
+      - uses: actions/configure-pages@v4
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,4 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  base: '/office/',
 })


### PR DESCRIPTION
## Problem
The Office Dashboard at osortega.github.io/office shows a blank page. The title shows "Office Dashboard" but no content renders.

## Root Causes
1. **Missing `base` path in Vite config** — Assets were being referenced from `/` instead of `/office/`, so the browser couldn't find the JS/CSS bundles on the GitHub Pages subpath.
2. **No CI/CD workflow** — There was no GitHub Actions workflow to build the project and deploy the `dist/` output to GitHub Pages.

## Changes
- **`vite.config.ts`**: Added `base: '/office/'` so all asset paths are prefixed correctly for the GitHub Pages subpath.
- **`.github/workflows/deploy.yml`**: Added a GitHub Actions workflow that builds the project on push to `main` and deploys the `dist/` directory to GitHub Pages using the modern `actions/deploy-pages` action.

## Verification
- `npm run build` succeeds and the built `dist/index.html` correctly references assets at `/office/assets/...`