### PR TITLE
Fix: Blank page on GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,14 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+      - name: Configure Pages to use Actions deployment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/pages \
+            -X PUT \
+            -f build_type=workflow 2>/dev/null || true
+
       - uses: actions/configure-pages@v4
 
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Problem
The Office Dashboard at https://osortega.github.io/office shows a blank page. The page loads with HTTP 200 and the correct title, but no content renders.

## Root Cause
GitHub Pages is serving the raw source `index.html` from the `main` branch instead of the built Vite output. This happens because:

1. `actions/configure-pages@v4` tries to **POST** (create) Pages with `build_type=workflow`
2. If Pages is already enabled, the API returns **409 Conflict**
3. The action silently continues **without updating** the build_type
4. Pages remains configured for branch-based deployment from `main`
5. The raw `index.html` serves `<script type="module" src="/src/main.tsx">` which 404s in production
6. Result: blank page with no JS or CSS loaded

**Evidence:** Fetching `https://osortega.github.io/office/src/main.tsx` returns the raw TypeScript source, confirming Pages serves from the repo root.

## Fix
Added an explicit `PUT` API call before `configure-pages` to set `build_type=workflow`, ensuring Pages serves from the GitHub Actions deployment artifact (the built `dist/` directory).

## Verification
- Local build succeeds and produces correct output with `/office/` base path
- Built `index.html` correctly references `/office/assets/index-*.js` and `/office/assets/index-*.css`
- All Tailwind CSS utility classes are generated in the build output
- All React components compile without errors

## Manual Step (if API call lacks permissions)
If the `gh api` call fails due to insufficient permissions, a repo admin needs to:
1. Go to **Settings > Pages > Source**
2. Change from "Deploy from a branch" to **"GitHub Actions"**