### PR TITLE
fix: deploy built assets to gh-pages branch to fix blank page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -31,15 +31,22 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      - name: Configure Pages to use Actions deployment
+      # Try to switch Pages to Actions-based deployment.
+      # This may fail if the GITHUB_TOKEN lacks admin-level access;
+      # the gh-pages branch fallback below handles that case.
+      - name: Try switching Pages to Actions deployment
+        continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api repos/${{ github.repository }}/pages \
-            -X PUT \
-            -f build_type=workflow 2>/dev/null || true
+            --method PUT \
+            --field build_type=workflow || \
+            echo "::warning::Could not update Pages build_type — see fallback step"
 
       - uses: actions/configure-pages@v4
+        with:
+          enablement: true
 
       - uses: actions/upload-pages-artifact@v3
         with:
@@ -47,3 +54,20 @@ jobs:
 
       - id: deployment
         uses: actions/deploy-pages@v4
+
+      # Fallback: push built output to gh-pages branch so the site
+      # works even when Pages is configured for branch deployment.
+      - name: Deploy to gh-pages branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd dist
+          touch .nojekyll
+          git init
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Deploy ${GITHUB_SHA}"
+          git push --force \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" \
+            HEAD:gh-pages


### PR DESCRIPTION
## Problem

The Office Dashboard at https://osortega.github.io/office shows a **blank page**. The page loads (HTTP 200) with the correct title, but no content renders.

### Root Cause

GitHub Pages is configured for **branch-based deployment** (serving source files from `main` branch). The source `index.html` references `/src/main.tsx` — browsers cannot process `.tsx` files, so the React app never mounts and the page stays blank.

The previous fix (PR #5) added a `gh api PUT` call to switch `build_type` to `workflow`, but this silently failed because:
1. The error was suppressed with `2>/dev/null || true`
2. The `GITHUB_TOKEN` likely lacks the admin-level permissions needed to change the Pages source configuration via the REST API

### Fix

- **Push built `dist/` output to a `gh-pages` branch** as a reliable fallback for branch-based deployment. This only requires `contents: write` permission (which `GITHUB_TOKEN` always has).
- Remove error suppression on the API call so failures are visible (`continue-on-error: true` instead of `2>/dev/null || true`)
- Set `enablement: true` on `configure-pages@v4` so it attempts to enable Actions-based deployment
- Change `permissions.contents` from `read` to `write` (needed for `git push`)

### After Merging

After the workflow runs, go to **Settings → Pages** and set the source to either:
- **GitHub Actions** (preferred), or
- **Deploy from branch** → `gh-pages` / `/ (root)`