### PR TITLE
fix: deploy to gh-pages branch to fix blank dashboard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -17,9 +15,6 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -31,32 +26,19 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      # Try to switch Pages to Actions-based deployment.
-      # This may fail if the GITHUB_TOKEN lacks admin-level access;
-      # the gh-pages branch fallback below handles that case.
-      - name: Try switching Pages to Actions deployment
+      # Ensure Pages source is set to the gh-pages branch
+      - name: Configure Pages source
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api repos/${{ github.repository }}/pages \
             --method PUT \
-            --field build_type=workflow || \
-            echo "::warning::Could not update Pages build_type — see fallback step"
+            --input - <<'EOF'
+          {"build_type":"legacy","source":{"branch":"gh-pages","path":"/"}}
+          EOF
 
-      - uses: actions/configure-pages@v4
-        with:
-          enablement: true
-
-      - uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
-      - id: deployment
-        uses: actions/deploy-pages@v4
-
-      # Fallback: push built output to gh-pages branch so the site
-      # works even when Pages is configured for branch deployment.
+      # Deploy built output to gh-pages branch
       - name: Deploy to gh-pages branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The Office Dashboard at osortega.github.io/office/ loads (HTTP 200, correct title) but appears completely blank with no visible content.

## Root Cause

GitHub Pages was configured with `build_type: legacy` and `source.branch: main`, serving the raw source `index.html` which references `/src/main.tsx` — a TypeScript/JSX file that browsers cannot execute. The page loaded but the React app never mounted.

The previous deploy workflow used `actions/deploy-pages@v4` (Actions-based deployment), but this was silently ignored because Pages was in legacy (branch-based) mode. The `gh-pages` branch fallback had the correct built output, but Pages was not configured to serve from it.

## Fix

1. **Updated Pages config** to serve from the `gh-pages` branch (applied via API)
2. **Simplified the deploy workflow** to only use the gh-pages branch deployment (removed unused Actions-based deployment steps that were being ignored)
3. Added a `Configure Pages source` step to ensure Pages stays pointed at `gh-pages`

## Verification

- ✅ Site now serves the built `index.html` with compiled JS/CSS assets
- ✅ JS bundle loads: `/office/assets/index-BEQqBMfn.js` (HTTP 200)
- ✅ CSS bundle loads: `/office/assets/index-VVgEF8JT.css` (HTTP 200)
- ✅ Dashboard renders: Header, Office Floor with 4 agent desks, Portfolio panel with 3 projects
- ✅ Build passes locally: `npm run build` succeeds