### PR TITLE
feat: fetch real data from CTO bot API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { fetchDashboard, DashboardData } from './services/api';
+import { fetchDashboard, DashboardData, ApiWorker } from './services/api';
 import { Agent, Project } from './data/types';
 import Header from './components/Header';
 import OfficeFloor from './components/OfficeFloor';
@@ -69,6 +69,7 @@ const POLL_INTERVAL = 10_000;
 export default function App() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
+  const [workers, setWorkers] = useState<ApiWorker[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
@@ -79,6 +80,7 @@ export default function App() {
       const { agents: a, projects: p } = transformData(data);
       setAgents(a);
       setProjects(p);
+      setWorkers(data.workers || []);
       setConnected(true);
       setError(null);
     } catch (err) {
@@ -122,7 +124,7 @@ export default function App() {
       )}
 
       <div className="flex flex-1 flex-col overflow-hidden lg:flex-row">
-        <OfficeFloor agents={agents} />
+        <OfficeFloor agents={agents} workers={workers} />
         <PortfolioPanel projects={projects} agents={agents} />
       </div>
     </div>

--- a/src/components/AgentDesk.tsx
+++ b/src/components/AgentDesk.tsx
@@ -104,6 +104,19 @@ export default function AgentDesk({ agent }: AgentDeskProps) {
             </p>
           </div>
         )}
+
+        {agent.skills && agent.skills.length > 0 && (
+          <div className="flex flex-wrap gap-1 pt-1">
+            {agent.skills.map((skill) => (
+              <span
+                key={skill}
+                className="rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500"
+              >
+                {skill}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/OfficeFloor.tsx
+++ b/src/components/OfficeFloor.tsx
@@ -1,12 +1,18 @@
 import { Agent } from '../data/types';
+import { ApiWorker } from '../services/api';
 import AgentDesk from './AgentDesk';
 import OfficeDecorations from './OfficeDecorations';
 
 interface OfficeFloorProps {
   agents: Agent[];
+  workers: ApiWorker[];
 }
 
-export default function OfficeFloor({ agents }: OfficeFloorProps) {
+export default function OfficeFloor({ agents, workers }: OfficeFloorProps) {
+  const activeWorkers = workers.filter(
+    (w) => w.status === 'running' || w.status === 'active' || w.status === 'busy'
+  );
+
   return (
     <div className="flex-1 overflow-auto p-6">
       {/* Floor header */}
@@ -19,6 +25,29 @@ export default function OfficeFloor({ agents }: OfficeFloorProps) {
           {agents.length} agents currently working
         </p>
       </div>
+
+      {/* Active workers banner */}
+      {activeWorkers.length > 0 && (
+        <div className="mb-6 rounded-xl border border-blue-100 bg-blue-50/60 p-4">
+          <h3 className="mb-2 text-sm font-semibold text-blue-800">
+            ⚡ Active Workers ({activeWorkers.length})
+          </h3>
+          <div className="space-y-2">
+            {activeWorkers.map((w) => (
+              <div
+                key={w.worker_id}
+                className="flex items-center justify-between rounded-lg bg-white/80 px-3 py-2 text-xs"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
+                  <span className="font-medium text-gray-800">{w.agent_name}</span>
+                </div>
+                <span className="text-gray-500 truncate ml-2 max-w-[200px]">{w.repo}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Office grid */}
       <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-2">

--- a/src/components/PortfolioPanel.tsx
+++ b/src/components/PortfolioPanel.tsx
@@ -67,6 +67,20 @@ export default function PortfolioPanel({ projects, agents }: PortfolioPanelProps
                 {project.description}
               </p>
 
+              {(project.repo || project.url) && (
+                <a
+                  href={project.url || `https://github.com/${project.repo}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-1 inline-flex items-center gap-1 text-[11px] text-indigo-500 hover:text-indigo-700"
+                >
+                  <svg className="h-3 w-3" fill="currentColor" viewBox="0 0 16 16">
+                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                  </svg>
+                  {project.repo || 'View project'}
+                </a>
+              )}
+
               {/* Progress bar */}
               <div className="mt-3">
                 <div className="flex items-center justify-between text-xs">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,4 @@
-const API_URL = import.meta.env.VITE_API_URL || 'https://openclaw.onrender.com/api/dashboard';
+const API_URL = import.meta.env.VITE_API_URL || 'https://cto.octanelabs.xyz/api/dashboard';
 
 export interface ApiAgent {
   name: string;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/office/',
+  base: '/',
 })


### PR DESCRIPTION
## Summary

Updates the Office Dashboard to fetch and display real data from the CTO bot API.

### Changes

- **API URL**: Updated default endpoint to `https://cto.octanelabs.xyz/api/dashboard`
- **Agent Skills**: Agent desk cards now display skills tags from the API
- **Active Workers**: New banner on the office floor showing currently active workers and their repos
- **Portfolio Links**: Project cards now link to their GitHub repos when available
- **Vercel Deployment**: Fixed `base` path to `/` and added `vercel.json` with SPA rewrite rules

### Loading & Error States

The existing loading spinner, error banner, and connection status indicator continue to work. The app polls every 10 seconds for fresh data.

### Testing

- `npm run build` passes successfully