### PR TITLE
fix: resolve blank page on GitHub Pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { fetchDashboard, DashboardData, ApiWorker } from './services/api';
+import { FALLBACK_DASHBOARD } from './data/mockData';
 import { Agent, Project } from './data/types';
 import Header from './components/Header';
 import OfficeFloor from './components/OfficeFloor';
@@ -92,6 +93,14 @@ export default function App() {
       const message = err instanceof Error ? err.message : 'Failed to connect to API';
       setError(message);
       setConnected(false);
+      // Use fallback data so the UI is never blank
+      if (agents.length === 0) {
+        const { agents: fa, projects: fp } = transformData(FALLBACK_DASHBOARD);
+        setAgents(fa);
+        setProjects(fp);
+        setWorkers(FALLBACK_DASHBOARD.workers || []);
+        setGoals(FALLBACK_DASHBOARD.goals || []);
+      }
     } finally {
       if (isInitial) setLoading(false);
       setRefreshing(false);

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,0 +1,80 @@
+import { DashboardData } from '../services/api';
+
+export const FALLBACK_DASHBOARD: DashboardData = {
+  agents: [
+    {
+      name: 'Devin',
+      role: 'Full-Stack Engineer',
+      description: 'Autonomous AI software engineer',
+      skills: ['TypeScript', 'Python', 'React'],
+      stats: { success_rate: 92 },
+      status: 'idle',
+      current_task: null,
+    },
+    {
+      name: 'Cursor',
+      role: 'Code Assistant',
+      description: 'AI-powered code editor',
+      skills: ['Code Review', 'Refactoring', 'Debugging'],
+      stats: { success_rate: 88 },
+      status: 'idle',
+      current_task: null,
+    },
+    {
+      name: 'Codex',
+      role: 'Backend Engineer',
+      description: 'Code generation and analysis',
+      skills: ['Python', 'Node.js', 'SQL'],
+      stats: { success_rate: 90 },
+      status: 'idle',
+      current_task: null,
+    },
+    {
+      name: 'Sweep',
+      role: 'DevOps Engineer',
+      description: 'Automated code maintenance',
+      skills: ['CI/CD', 'Testing', 'Documentation'],
+      stats: { success_rate: 85 },
+      status: 'idle',
+      current_task: null,
+    },
+  ],
+  workers: [],
+  projects: [
+    {
+      id: 'proj-demo-1',
+      name: 'Office Dashboard',
+      description: 'Real-time visualization of AI agent activity.',
+      status: 'active',
+      tasks: [
+        { name: 'Setup', status: 'done' },
+        { name: 'UI Components', status: 'done' },
+        { name: 'API Integration', status: 'in_progress' },
+      ],
+      agents: ['Devin', 'Cursor'],
+    },
+    {
+      id: 'proj-demo-2',
+      name: 'API Gateway',
+      description: 'Central API gateway for microservices.',
+      status: 'improving',
+      tasks: [
+        { name: 'Design', status: 'done' },
+        { name: 'Implementation', status: 'in_progress' },
+      ],
+      agents: ['Codex'],
+    },
+    {
+      id: 'proj-demo-3',
+      name: 'CI/CD Pipeline',
+      description: 'Automated build, test, and deployment pipeline.',
+      status: 'completed',
+      tasks: [
+        { name: 'Pipeline Setup', status: 'done' },
+        { name: 'Testing', status: 'done' },
+      ],
+      agents: ['Sweep'],
+    },
+  ],
+  goals: ['Demo mode — live data unavailable'],
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  base: '/office/',
 })


### PR DESCRIPTION
## Problem
The Office Dashboard at https://osortega.github.io/office shows a blank page. The page loads (HTTP 200) but no content renders.

## Root Causes
1. **Wrong Vite base path**: `base: '/'` caused all JS/CSS assets to load from `/assets/...` instead of `/office/assets/...`, resulting in 404s on GitHub Pages
2. **No fallback UI**: When the API at `cto.octanelabs.xyz` is unreachable (CORS/network errors), the app rendered empty arrays = blank screen

## Changes
- **`vite.config.ts`**: Set `base: '/office/'` so asset paths match the GitHub Pages URL
- **`src/data/mockData.ts`**: Added fallback dashboard data with demo agents and projects
- **`src/App.tsx`**: Load fallback data when API fails and no data has been fetched yet, so the UI always shows meaningful content

## Testing
- `npm run build` succeeds
- `npm run preview` serves correctly at `/office/`
- Assets load from `/office/assets/...` in the built output