### PR TITLE
fix: Configure Vercel deployment for office.octanelabs.xyz

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,19 +1,20 @@
-name: Deploy to GitHub Pages
+name: Deploy to Vercel
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 concurrency:
-  group: pages
+  group: deploy-production
   cancel-in-progress: true
 
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
 jobs:
-  build-and-deploy:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,33 +24,14 @@ jobs:
           node-version: 20
           cache: npm
 
-      - run: npm ci
-      - run: npm run build
+      - name: Install Vercel CLI
+        run: npm install -g vercel
 
-      # Ensure Pages source is set to the gh-pages branch
-      - name: Configure Pages source
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/${{ github.repository }}/pages \
-            --method PUT \
-            --input - <<'EOF'
-          {"build_type":"legacy","source":{"branch":"gh-pages","path":"/"}}
-          EOF
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
-      # Deploy built output to gh-pages branch
-      - name: Deploy to gh-pages branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cd dist
-          touch .nojekyll
-          git init
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "Deploy ${GITHUB_SHA}"
-          git push --force \
-            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" \
-            HEAD:gh-pages
+      - name: Build project
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }
   ]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,5 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/office/',
+  base: '/',
 })


### PR DESCRIPTION
## Problem

The site `office.octanelabs.xyz` is not resolving (DNS error). The deployment was configured for GitHub Pages with a subpath base `/office/`, not for Vercel with a custom domain.

## Changes

### 1. `vite.config.ts` — Fix base path
- Changed `base` from `'/office/'` to `'/'` so assets resolve correctly on the custom domain

### 2. `vercel.json` — Add build configuration
- Added `framework: "vite"`, `buildCommand`, and `outputDirectory` so Vercel correctly builds the Vite SPA
- Kept the SPA rewrite rule for client-side routing

### 3. `.github/workflows/deploy.yml` — Switch to Vercel deployment
- Replaced GitHub Pages workflow with Vercel CLI deployment
- Uses `vercel build --prod` and `vercel deploy --prebuilt --prod`
- Triggers on push to `main` and manual dispatch

## Required Secrets

Add these GitHub repository secrets for the workflow:
- `VERCEL_TOKEN` — Vercel API token
- `VERCEL_ORG_ID` — Vercel organization ID  
- `VERCEL_PROJECT_ID` — Vercel project ID

## Verification
- ✅ `npm run build` succeeds with the updated config
- The API URL defaults to `https://cto.octanelabs.xyz/api/dashboard` (no change needed)